### PR TITLE
Catch errors from exposed methods

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,7 @@ my %WriteMakefileArgs = (
     TEST_REQUIRES => {
         'Test::More'        => '0.88',
         'File::Spec'        => '0',
-        'Test::Log::Dispatch' => '0.03',
+        'List::Util'        => '1.33',
     },
 
     META_MERGE => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,6 +25,7 @@ my %WriteMakefileArgs = (
     TEST_REQUIRES => {
         'Test::More'        => '0.88',
         'File::Spec'        => '0',
+        'Test::Log::Dispatch' => '0.03',
     },
 
     META_MERGE => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,7 @@ my %WriteMakefileArgs = (
         'Path::Class'       => 0,
         'MRO::Compat'       => 0,
         'Data::Dump'        => 0,
+        'Try::Tiny'         => 0,
     },
     TEST_REQUIRES => {
         'Test::More'        => '0.88',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,6 @@ my %WriteMakefileArgs = (
         'Path::Class'       => 0,
         'MRO::Compat'       => 0,
         'Data::Dump'        => 0,
-        'Try::Tiny'         => 0,
     },
     TEST_REQUIRES => {
         'Test::More'        => '0.88',

--- a/t/12expose_methods.t
+++ b/t/12expose_methods.t
@@ -20,4 +20,8 @@ ok( $response = request("/test?view=ExposeMethods&template=exposed_method_fails.
 $TestApp::Log->contains_ok(qr/no param passed/);
 $TestApp::Log->clear;
 
+ok( $response = request("/test?view=ExposeMethods&template=other_exposed_method_dies.tt")->is_error, 'request fails');
+
+$TestApp::Log->contains_ok(qr/ouch that was unexpected/);
+
 done_testing;

--- a/t/12expose_methods.t
+++ b/t/12expose_methods.t
@@ -13,15 +13,15 @@ is($response->content, "magic added param", 'message ok');
 ok(($response = request("/test?view=ExposeMethodsSubclassed&template=expose_methods.tt"))->is_success, 'request ok');
 is($response->content, "magic added param", 'message ok');
 
-$TestApp::Log->empty_ok('no logged errors');
+ok $TestApp::Log->is_empty, "no logged errors";
 
 ok( $response = request("/test?view=ExposeMethods&template=exposed_method_fails.tt")->is_error, 'request fails');
 
-$TestApp::Log->contains_ok(qr/no param passed/);
+ok $TestApp::Log->contains( sub { $_[0] =~ /no param passed/ } ), 'expected log message';
 $TestApp::Log->clear;
 
 ok( $response = request("/test?view=ExposeMethods&template=other_exposed_method_dies.tt")->is_error, 'request fails');
 
-$TestApp::Log->contains_ok(qr/ouch that was unexpected/);
+ok $TestApp::Log->contains( sub { $_[0] =~ /ouch that was unexpected/ } ), 'expected log message';
 
 done_testing;

--- a/t/12expose_methods.t
+++ b/t/12expose_methods.t
@@ -13,4 +13,11 @@ is($response->content, "magic added param", 'message ok');
 ok(($response = request("/test?view=ExposeMethodsSubclassed&template=expose_methods.tt"))->is_success, 'request ok');
 is($response->content, "magic added param", 'message ok');
 
+$TestApp::Log->empty_ok('no logged errors');
+
+ok( $response = request("/test?view=ExposeMethods&template=exposed_method_fails.tt")->is_error, 'request fails');
+
+$TestApp::Log->contains_ok(qr/no param passed/);
+$TestApp::Log->clear;
+
 done_testing;

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -5,8 +5,13 @@ use warnings;
 
 use Catalyst; # qw/-Debug/;
 use Path::Class;
+use Test::Log::Dispatch;
+
+our $Log = Test::Log::Dispatch->new;
 
 our $VERSION = '0.01';
+
+__PACKAGE__->log( $Log );
 
 __PACKAGE__->config(
     name                  => 'TestApp',
@@ -21,4 +26,3 @@ __PACKAGE__->config(
 );
 
 __PACKAGE__->setup;
-

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -5,9 +5,9 @@ use warnings;
 
 use Catalyst; # qw/-Debug/;
 use Path::Class;
-use Test::Log::Dispatch;
+use TestLogger;
 
-our $Log = Test::Log::Dispatch->new;
+our $Log = TestLogger->new;
 
 our $VERSION = '0.01';
 

--- a/t/lib/TestApp/View/TT/ExposeMethods.pm
+++ b/t/lib/TestApp/View/TT/ExposeMethods.pm
@@ -4,7 +4,7 @@ use Moose;
 extends 'Catalyst::View::TT';
 
 __PACKAGE__->config(
-  expose_methods => [q/exposed_method/],
+  expose_methods => [qw/exposed_method other_exposed_method/],
 );
 
 sub exposed_method {
@@ -16,5 +16,9 @@ sub exposed_method {
     return 'magic ' . $some_param;
 }
 
+sub other_exposed_method {
+    my ($self, $c) = @_;
+    die "ouch that was unexpected";
+}
 
 1;

--- a/t/lib/TestApp/root/exposed_method_fails.tt
+++ b/t/lib/TestApp/root/exposed_method_fails.tt
@@ -1,0 +1,1 @@
+[% exposed_method() %]

--- a/t/lib/TestApp/root/other_exposed_method_dies.tt
+++ b/t/lib/TestApp/root/other_exposed_method_dies.tt
@@ -1,0 +1,1 @@
+[% other_exposed_method() %]

--- a/t/lib/TestLogger.pm
+++ b/t/lib/TestLogger.pm
@@ -1,0 +1,38 @@
+package TestLogger;
+
+use strict;
+use warnings;
+
+use List::Util ();
+
+our @Logs;
+
+sub new {
+    return bless { }, __PACKAGE__;
+}
+
+sub debug { }
+
+sub info { }
+
+sub warn { }
+
+sub error {
+    my ($self, $message) = @_;
+    push @Logs, { level => 'error', message => $message };
+}
+
+sub clear {
+    @Logs = ();
+}
+
+sub is_empty {
+    return scalar(@Logs) == 0;
+}
+
+sub contains {
+    my ($self, $check) = @_;
+    return List::Util::any { $check->( $_->{message} ) } @Logs;
+}
+
+1;


### PR DESCRIPTION
When an exposed method dies, rendering will fail with an unhelpful error:
> Couldn't render template "[path to template]: undef error - "

This fixes that by wrapping the method in a try/catch block, and throwing any caught errors.

This also adds tests for logged errors.